### PR TITLE
More fixes

### DIFF
--- a/Source/ProceduralMeshDemos/BranchingLinesActor.h
+++ b/Source/ProceduralMeshDemos/BranchingLinesActor.h
@@ -85,7 +85,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	uint8 Iterations = 5;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "3"))
 	int32 RadialSegmentCount = 10;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")

--- a/Source/ProceduralMeshDemos/BranchingMeshActor.cpp
+++ b/Source/ProceduralMeshDemos/BranchingMeshActor.cpp
@@ -987,6 +987,8 @@ void ABranchingMeshActor::GenerateEndCaps(const TArray<FBranchNode>& Nodes, cons
 
 void ABranchingMeshActor::GenerateCollision(const TArray<FBranchPath>& Paths)
 {
+	MeshComponent->ClearCollisionConvexMeshes();
+
 	if (CollisionType == EBranchCollisionType::None)
 	{
 		MeshComponent->SetCollisionEnabled(ECollisionEnabled::NoCollision);

--- a/Source/ProceduralMeshDemos/BranchingMeshActor.h
+++ b/Source/ProceduralMeshDemos/BranchingMeshActor.h
@@ -44,7 +44,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	float TrunkWidth = 2.5f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "3"))
 	int32 RadialSegmentCount = 10;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")

--- a/Source/ProceduralMeshDemos/CylinderStripActor.h
+++ b/Source/ProceduralMeshDemos/CylinderStripActor.h
@@ -23,7 +23,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	float Radius = 10;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "3"))
 	int32 RadialSegmentCount = 10;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")

--- a/Source/ProceduralMeshDemos/HeightFieldAnimatedActor.cpp
+++ b/Source/ProceduralMeshDemos/HeightFieldAnimatedActor.cpp
@@ -126,16 +126,17 @@ void AHeightFieldAnimatedActor::GenerateMesh()
 
 	SetupMeshBuffers();
 	GeneratePoints();
-	GenerateGrid(Positions, Triangles, Normals, TexCoords, FVector2D(Size.X, Size.Y), LengthSections, WidthSections, HeightValues);
 
 	if (bMeshCreated)
 	{
-		// Fast path: update positions and normals in-place without recreating the scene proxy
+		// Fast path: only recompute positions and normals, skip triangles and UVs
+		UpdatePositionsAndNormals(FVector2D(Size.X, Size.Y), LengthSections, WidthSections, HeightValues);
 		MeshComponent->UpdateMeshSection(0, Positions, Normals, TexCoords, {}, {}, {}, {}, {});
 	}
 	else
 	{
-		// Initial creation
+		// Full rebuild: topology + positions + normals + UVs
+		GenerateGrid(FVector2D(Size.X, Size.Y), LengthSections, WidthSections, HeightValues);
 		MeshComponent->ClearAllMeshSections();
 		MeshComponent->CreateMeshSection_LinearColor(0, Positions, Triangles, Normals, TexCoords, {}, {}, {}, {}, {}, false);
 		if (Material)
@@ -146,55 +147,73 @@ void AHeightFieldAnimatedActor::GenerateMesh()
 	}
 }
 
-void AHeightFieldAnimatedActor::GenerateGrid(TArray<FVector>& InVertices, TArray<int32>& InTriangles, TArray<FVector>& InNormals, TArray<FVector2D>& InTexCoords, const FVector2D InSize, const int32 InLengthSections, const int32 InWidthSections, const TArray<float>& InHeightValues)
+void AHeightFieldAnimatedActor::GenerateGrid(const FVector2D InSize, const int32 InLengthSections, const int32 InWidthSections, const TArray<float>& InHeightValues)
 {
-	// Note the coordinates are a bit weird here since I aligned it to the transform (X is forwards or "up", which Y is to the right)
-	// Should really fix this up and use standard X, Y coords then transform into object space?
 	const FVector2D SectionSize = FVector2D(InSize.X / InLengthSections, InSize.Y / InWidthSections);
 	int32 VertexIndex = 0;
 	int32 TriangleIndex = 0;
 
 	const float LengthSectionsAsFloat = static_cast<float>(InLengthSections);
 	const float WidthSectionsAsFloat = static_cast<float>(InWidthSections);
-	
+
 	for (int32 X = 0; X < InLengthSections + 1; X++)
 	{
 		for (int32 Y = 0; Y < InWidthSections + 1; Y++)
 		{
-			// Create a new vertex
 			const int32 NewVertIndex = VertexIndex++;
-			const FVector NewVertex = FVector(X * SectionSize.X, Y * SectionSize.Y, InHeightValues[NewVertIndex]);
-			InVertices[NewVertIndex] = NewVertex;
+			Positions[NewVertIndex] = FVector(X * SectionSize.X, Y * SectionSize.Y, InHeightValues[NewVertIndex]);
 
 			// Note that Unreal UV origin (0,0) is top left
 			const float U = static_cast<float>(X) / LengthSectionsAsFloat;
 			const float V = static_cast<float>(Y) / WidthSectionsAsFloat;
-			InTexCoords[NewVertIndex] = FVector2D(U, V);
+			TexCoords[NewVertIndex] = FVector2D(U, V);
 
 			// Once we've created enough verts we can start adding polygons
 			if (X > 0 && Y > 0)
 			{
-				// Each row is InWidthSections+1 number of points.
-				// And we have InLength+1 rows
-				// Index of current vertex in position is thus: (X * (InWidthSections + 1)) + Y;
-				const int32 TopRightIndex = (X * (InWidthSections + 1)) + Y; // Should be same as VertIndex1!
+				const int32 TopRightIndex = (X * (InWidthSections + 1)) + Y;
 				const int32 TopLeftIndex = TopRightIndex - 1;
 				const int32 BottomRightIndex = ((X - 1) * (InWidthSections + 1)) + Y;
 				const int32 BottomLeftIndex = BottomRightIndex - 1;
 
-				// Now create two triangles from those four vertices
-				// The order of these (clockwise/counter-clockwise) dictates which way the normal will face. 
-				InTriangles[TriangleIndex++] = BottomLeftIndex;
-				InTriangles[TriangleIndex++] = TopRightIndex;
-				InTriangles[TriangleIndex++] = TopLeftIndex;
+				// The order of these (clockwise/counter-clockwise) dictates which way the normal will face.
+				Triangles[TriangleIndex++] = BottomLeftIndex;
+				Triangles[TriangleIndex++] = TopRightIndex;
+				Triangles[TriangleIndex++] = TopLeftIndex;
 
-				InTriangles[TriangleIndex++] = BottomLeftIndex;
-				InTriangles[TriangleIndex++] = BottomRightIndex;
-				InTriangles[TriangleIndex++] = TopRightIndex;
+				Triangles[TriangleIndex++] = BottomLeftIndex;
+				Triangles[TriangleIndex++] = BottomRightIndex;
+				Triangles[TriangleIndex++] = TopRightIndex;
 
 				// Normals
-				const FVector NormalCurrent = FVector::CrossProduct(InVertices[BottomLeftIndex] - InVertices[TopLeftIndex], InVertices[TopLeftIndex] - InVertices[TopRightIndex]).GetSafeNormal();
-				InNormals[BottomLeftIndex] = InNormals[BottomRightIndex] = InNormals[TopRightIndex] = InNormals[TopLeftIndex] = NormalCurrent;
+				const FVector NormalCurrent = FVector::CrossProduct(Positions[BottomLeftIndex] - Positions[TopLeftIndex], Positions[TopLeftIndex] - Positions[TopRightIndex]).GetSafeNormal();
+				Normals[BottomLeftIndex] = Normals[BottomRightIndex] = Normals[TopRightIndex] = Normals[TopLeftIndex] = NormalCurrent;
+			}
+		}
+	}
+}
+
+void AHeightFieldAnimatedActor::UpdatePositionsAndNormals(const FVector2D InSize, const int32 InLengthSections, const int32 InWidthSections, const TArray<float>& InHeightValues)
+{
+	const FVector2D SectionSize = FVector2D(InSize.X / InLengthSections, InSize.Y / InWidthSections);
+	int32 VertexIndex = 0;
+
+	for (int32 X = 0; X < InLengthSections + 1; X++)
+	{
+		for (int32 Y = 0; Y < InWidthSections + 1; Y++)
+		{
+			const int32 NewVertIndex = VertexIndex++;
+			Positions[NewVertIndex] = FVector(X * SectionSize.X, Y * SectionSize.Y, InHeightValues[NewVertIndex]);
+
+			if (X > 0 && Y > 0)
+			{
+				const int32 TopRightIndex = (X * (InWidthSections + 1)) + Y;
+				const int32 TopLeftIndex = TopRightIndex - 1;
+				const int32 BottomRightIndex = ((X - 1) * (InWidthSections + 1)) + Y;
+				const int32 BottomLeftIndex = BottomRightIndex - 1;
+
+				const FVector NormalCurrent = FVector::CrossProduct(Positions[BottomLeftIndex] - Positions[TopLeftIndex], Positions[TopLeftIndex] - Positions[TopRightIndex]).GetSafeNormal();
+				Normals[BottomLeftIndex] = Normals[BottomRightIndex] = Normals[TopRightIndex] = Normals[TopLeftIndex] = NormalCurrent;
 			}
 		}
 	}

--- a/Source/ProceduralMeshDemos/HeightFieldAnimatedActor.h
+++ b/Source/ProceduralMeshDemos/HeightFieldAnimatedActor.h
@@ -59,7 +59,8 @@ protected:
 private:
 	void GenerateMesh();
 	void GeneratePoints();
-	static void GenerateGrid(TArray<FVector>& InVertices, TArray<int32>& InTriangles, TArray<FVector>& InNormals, TArray<FVector2D>& InTexCoords, const FVector2D InSize, const int32 InLengthSections, const int32 InWidthSections, const TArray<float>& InHeightValues);
+	void GenerateGrid(const FVector2D InSize, const int32 InLengthSections, const int32 InWidthSections, const TArray<float>& InHeightValues);
+	void UpdatePositionsAndNormals(const FVector2D InSize, const int32 InLengthSections, const int32 InWidthSections, const TArray<float>& InHeightValues);
 
 	TArray<float> HeightValues;
 	float MaxHeightValue = 0.0f;

--- a/Source/ProceduralMeshDemos/HeightFieldNoiseActor.cpp
+++ b/Source/ProceduralMeshDemos/HeightFieldNoiseActor.cpp
@@ -128,9 +128,9 @@ void AHeightFieldNoiseActor::GenerateGrid(TArray<FVector>& InVertices, TArray<in
 			const int32 TopRightIndex = VertexIndex++;
 			const int32 TopLeftIndex = VertexIndex++;
 
-			const int32 NoiseIndex_BottomLeft = (X * InWidthSections) + Y;
+			const int32 NoiseIndex_BottomLeft = (X * (InWidthSections + 1)) + Y;
 			const int32 NoiseIndex_BottomRight = NoiseIndex_BottomLeft + 1;
-			const int32 NoiseIndex_TopLeft = ((X+1) * InWidthSections) + Y;
+			const int32 NoiseIndex_TopLeft = ((X + 1) * (InWidthSections + 1)) + Y;
 			const int32 NoiseIndex_TopRight = NoiseIndex_TopLeft + 1;
 
 			const FVector PBottomLeft = FVector(X * SectionSize.X, Y * SectionSize.Y, InHeightValues[NoiseIndex_BottomLeft]);

--- a/Source/ProceduralMeshDemos/SierpinskiLineActor.h
+++ b/Source/ProceduralMeshDemos/SierpinskiLineActor.h
@@ -57,7 +57,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	float Size = 400.0f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "0", ClampMax = "8"))
 	int32 Iterations = 5;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
@@ -66,7 +66,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	float ThicknessMultiplierPerGeneration = 0.8f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "3"))
 	int32 RadialSegmentCount = 4;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")

--- a/Source/ProceduralMeshDemos/SimpleCylinderActor.h
+++ b/Source/ProceduralMeshDemos/SimpleCylinderActor.h
@@ -23,7 +23,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	float Height = 100;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "3"))
 	int32 RadialSegmentCount = 10;
 
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")

--- a/Source/ProceduralMeshDemos/SmoothCylinderStripActor.h
+++ b/Source/ProceduralMeshDemos/SmoothCylinderStripActor.h
@@ -30,7 +30,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
 	float Radius = 10.f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters")
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Procedural Parameters", meta = (ClampMin = "3"))
 	int32 RadialSegmentCount = 10;
 
 	/** Number of interpolation steps per joint. 0 = sharp miter, higher = smoother arc. */


### PR DESCRIPTION
- Fixing wrong stride in GenerateGrid in HeightFieldNoiseActor
- BranchingMeshActor - Fixed accumulating convex hulls on property changes
- Capped min of RadialSegmentCount in many actors
- Added max clamp to iteration in SierpinskiLineActor
- Increase performance of Faster HeightFieldAnimatedActor but splitting mesh generation from updates that only need to update vertex location and normal